### PR TITLE
ARCH-11: Fix PHP 8.1 deprecation warnings on Helper and FormHelper

### DIFF
--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -632,7 +632,7 @@ class Helper extends CakeObject {
  * @return array An array containing the identity elements of an entity
  */
 	public function entity() {
-		return explode('.', $this->_entityPath);
+		return explode('.', (string)$this->_entityPath);
 	}
 
 /**

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2767,7 +2767,19 @@ class FormHelper extends AppHelper {
 		}
 
 		if (is_numeric($value)) {
-			$value = strftime('%Y-%m-%d %H:%M:%S', $value);
+			try {
+				$value = datefmt_format(
+					datefmt_create(
+						locale: setLocale(LC_TIME, 0),
+						dateType: \IntlDateFormatter::FULL,
+						timeType: \IntlDateFormatter::FULL,
+						pattern: 'yyyy-MM-dd HH:mm:SS'
+					),
+					$value
+				);
+			} catch (\Error) {
+				$value = date('Y-m-d H:i:s', $value);
+			}
 		}
 		$meridian = 'am';
 		$pos = strpos($value, '-');
@@ -3021,7 +3033,19 @@ class FormHelper extends AppHelper {
 					$data = $options['monthNames'];
 				} else {
 					for ($m = 1; $m <= 12; $m++) {
-						$data[sprintf("%02s", $m)] = strftime("%m", mktime(1, 1, 1, $m, 1, 1999));
+						try {
+							$data[sprintf("%02s", $m)] = datefmt_format(
+								datefmt_create(
+									locale: setLocale(LC_TIME, 0),
+									dateType: \IntlDateFormatter::FULL,
+									timeType: \IntlDateFormatter::FULL,
+									pattern: 'MM'
+								),
+								mktime(1, 1, 1, $m, 1, 1999)
+							);
+						} catch (\Error) {
+							$data[sprintf("%02s", $m)] = date('m', mktime(1, 1, 1, $m, 1, 1999));
+						}
 					}
 				}
 				break;

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2767,19 +2767,7 @@ class FormHelper extends AppHelper {
 		}
 
 		if (is_numeric($value)) {
-			try {
-				$value = datefmt_format(
-					datefmt_create(
-						locale: setLocale(LC_TIME, 0),
-						dateType: \IntlDateFormatter::FULL,
-						timeType: \IntlDateFormatter::FULL,
-						pattern: 'yyyy-MM-dd HH:mm:SS'
-					),
-					$value
-				);
-			} catch (\Error) {
-				$value = date('Y-m-d H:i:s', $value);
-			}
+			$value = strftime('%Y-%m-%d %H:%M:%S', $value);
 		}
 		$meridian = 'am';
 		$pos = strpos($value, '-');
@@ -3033,19 +3021,7 @@ class FormHelper extends AppHelper {
 					$data = $options['monthNames'];
 				} else {
 					for ($m = 1; $m <= 12; $m++) {
-						try {
-							$data[sprintf("%02s", $m)] = datefmt_format(
-								datefmt_create(
-									locale: setLocale(LC_TIME, 0),
-									dateType: \IntlDateFormatter::FULL,
-									timeType: \IntlDateFormatter::FULL,
-									pattern: 'MM'
-								),
-								mktime(1, 1, 1, $m, 1, 1999)
-							);
-						} catch (\Error) {
-							$data[sprintf("%02s", $m)] = date('m', mktime(1, 1, 1, $m, 1, 1999));
-						}
+						$data[sprintf("%02s", $m)] = strftime("%m", mktime(1, 1, 1, $m, 1, 1999));
 					}
 				}
 				break;


### PR DESCRIPTION
- fix deprecation warning when Helper::_entityPath is null
- fix `strftime` function deprecation warning on FormHelper::_getDateTimeValue method